### PR TITLE
ConcatenatedRow: Don't treat '0' as empty

### DIFF
--- a/src/MUtil/Model/Type/ConcatenatedRow.php
+++ b/src/MUtil/Model/Type/ConcatenatedRow.php
@@ -195,7 +195,7 @@ class MUtil_Model_Type_ConcatenatedRow
                 $value = trim($value, $this->seperatorChar);
             }
             // If it was empty, return an empty array instead of array with an empty element
-            if(empty($value)) {
+            if(!isset($value) || $value === false || $value === null || $value === '') {
                 return array();
             }
             $value = explode($this->seperatorChar, $value);


### PR DESCRIPTION
This fixes an issue where a multiselect of value '|0|' would show item 0 as selected when showing the value.