### PR TITLE
2.x curltimeout

### DIFF
--- a/src/MUtil/Validate/ExistingUrl.php
+++ b/src/MUtil/Validate/ExistingUrl.php
@@ -112,6 +112,7 @@ class ExistingUrl extends AbstractValidator
                      */
                     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
                     curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+                    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
 
                     $valid = curl_exec($ch);
                     if (! $valid) {


### PR DESCRIPTION
Fixes timeouts with connections to sites that exist in DNS but aren't reachable (and that don't give a connection refused or other response).