### PR TITLE
ExistingUrl: Specify a connect timeout

### DIFF
--- a/src/MUtil/Validator/ExistingUrl.php
+++ b/src/MUtil/Validator/ExistingUrl.php
@@ -112,6 +112,7 @@ class ExistingUrl extends AbstractValidator
                      */
                     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
                     curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+                    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
 
                     $valid = curl_exec($ch);
                     if (! $valid) {

--- a/src/MUtil/Validator/ExistingUrl.php
+++ b/src/MUtil/Validator/ExistingUrl.php
@@ -113,6 +113,7 @@ class ExistingUrl extends AbstractValidator
                     curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
                     curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
                     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+                    curl_setopt($ch, CURLOPT_TIMEOUT, 8);
 
                     $valid = curl_exec($ch);
                     if (! $valid) {


### PR DESCRIPTION
The default curl connect timeout is 300 seconds. Set it to something much lower to avoid timeouts elsewhere.

This fixes an issue where a user would enter a url for which the DNS existed, but which was not reachable. The application seemed to freeze, while the php-pfm processes were happily waiting for the curl timeout. After a few refreshes, the php-fpm worker process were exhausted and the application was no longer usable.