### PR TITLE
ModelAbstract: Allow transformers to return 0 or empty results

### DIFF
--- a/src/MUtil/Model/ModelAbstract.php
+++ b/src/MUtil/Model/ModelAbstract.php
@@ -1291,7 +1291,7 @@ abstract class ModelAbstract extends \MUtil\Registry\TargetAbstract implements F
     public function getOnLoad($value, $new, $name, array $context = array(), $isPost = false)
     {
         $call = $this->get($name, self::LOAD_TRANSFORMER);
-        if ($call) {
+        if (!is_null($call)) {
              if (is_callable($call)) {
                  $value = call_user_func($call, $value, $new, $name, $context, $isPost);
              } else {
@@ -1314,7 +1314,8 @@ abstract class ModelAbstract extends \MUtil\Registry\TargetAbstract implements F
      */
     public function getOnSave($value, $new, $name, array $context = array())
     {
-        if ($call = $this->get($name, self::SAVE_TRANSFORMER)) {
+        $call = $this->get($name, self::SAVE_TRANSFORMER);
+        if (!is_null($call)) {
 
             if (is_callable($call)) {
                 $value = call_user_func($call, $value, $new, $name, $context);


### PR DESCRIPTION
Required for gemstracker Model::setChangeFieldsByPrefix() to work when no user is logged in: the userid to add is UserLoader::UNKNOWN_USER_ID in that case, which is 0. When the transformer returned 0, the column/value was not added to the sql query after processing. This change ensures that the values 0 and an empty string are not ignored when they are returned by a transformer.

Change getOnLoad() to keep things identical.