### PR TITLE
PluginLoader: Check the exact value added to the paths list

### DIFF
--- a/src/MUtil/Loader/PluginLoader.php
+++ b/src/MUtil/Loader/PluginLoader.php
@@ -83,7 +83,7 @@ class PluginLoader extends \Zend_Loader_PluginLoader
 
             // \MUtil\EchoOut\EchoOut::track(self::getAbsolutePaths($path));
             foreach (self::getAbsolutePaths($path) as $sub) {
-                if (! in_array($sub, $newPaths)) {
+                if (! in_array($sub . DIRECTORY_SEPARATOR, $newPaths)) {
                     if ($prepend) {
                         array_unshift($newPaths, $sub . DIRECTORY_SEPARATOR);
                     } else {


### PR DESCRIPTION
This fixes an issue where we would check if a path existed in an array without its trailing slash, after which we would add it *with* a trailing slash. The result is that the check would always fail, so the path would always be added. Depending on how many times this was done, the number of identical paths in the list could become quite large, causing troubling slowness later on.