### PR TITLE
composer: Depend on shardj/zf1-future 1.23

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "magnafacta/zalt-model": "^2.0.3",
         "psr/http-message": "^1.0.1",
         "psr/cache": "^3.0",
-        "shardj/zf1-future": "^1.21",
+        "shardj/zf1-future": "^1.23",
         "shardj/zf1-extras-future": "^1.12",
         "symfony/translation": "^6.1",
         "symfony/finder": "^6.1"


### PR DESCRIPTION
This fixes a bunch of phpstan errors in Gemstracker when we run composer update with --prefer-lowest.